### PR TITLE
clk: imx6q: keep the CAAM clock enabled

### DIFF
--- a/drivers/clk/imx/clk-imx6q.c
+++ b/drivers/clk/imx/clk-imx6q.c
@@ -798,9 +798,9 @@ static void __init imx6q_clocks_init(struct device_node *ccm_node)
 	hws[IMX6QDL_CLK_ASRC]         = imx_clk_hw_gate2_shared("asrc",         "asrc_podf",   base + 0x68, 6, &share_count_asrc);
 	hws[IMX6QDL_CLK_ASRC_IPG]     = imx_clk_hw_gate2_shared("asrc_ipg",     "ahb",         base + 0x68, 6, &share_count_asrc);
 	hws[IMX6QDL_CLK_ASRC_MEM]     = imx_clk_hw_gate2_shared("asrc_mem",     "ahb",         base + 0x68, 6, &share_count_asrc);
-	hws[IMX6QDL_CLK_CAAM_MEM]     = imx_clk_hw_gate2("caam_mem",      "ahb",               base + 0x68, 8);
-	hws[IMX6QDL_CLK_CAAM_ACLK]    = imx_clk_hw_gate2("caam_aclk",     "ahb",               base + 0x68, 10);
-	hws[IMX6QDL_CLK_CAAM_IPG]     = imx_clk_hw_gate2("caam_ipg",      "ipg",               base + 0x68, 12);
+	hws[IMX6QDL_CLK_CAAM_MEM]     = imx_clk_hw_gate2_flags("caam_mem",      "ahb",               base + 0x68, 8,  CLK_IGNORE_UNUSED);
+	hws[IMX6QDL_CLK_CAAM_ACLK]    = imx_clk_hw_gate2_flags("caam_aclk",     "ahb",               base + 0x68, 10, CLK_IGNORE_UNUSED);
+	hws[IMX6QDL_CLK_CAAM_IPG]     = imx_clk_hw_gate2_flags("caam_ipg",      "ipg",               base + 0x68, 12, CLK_IGNORE_UNUSED);
 	hws[IMX6QDL_CLK_CAN1_IPG]     = imx_clk_hw_gate2("can1_ipg",      "ipg",               base + 0x68, 14);
 	hws[IMX6QDL_CLK_CAN1_SERIAL]  = imx_clk_hw_gate2("can1_serial",   "can_root",          base + 0x68, 16);
 	hws[IMX6QDL_CLK_CAN2_IPG]     = imx_clk_hw_gate2("can2_ipg",      "ipg",               base + 0x68, 18);


### PR DESCRIPTION
Since the TEE will be using the CAAM, set the CLK_IGNORE_UNUSED flag
on these clocks to prevent the kernel from gating them.

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>