### PR TITLE
ARM: dts: stm32mp157c-dk2: enable i2c5 bus

### DIFF
--- a/arch/arm/boot/dts/stm32mp157c-dk2.dts
+++ b/arch/arm/boot/dts/stm32mp157c-dk2.dts
@@ -22,6 +22,7 @@
 		serial1 = &usart3;
 		serial2 = &uart7;
 		serial3 = &usart2;
+		i2c5 = &i2c5;
 	};
 
 	chosen {
@@ -84,6 +85,10 @@
 		touchscreen-size-y = <800>;
 		status = "okay";
 	};
+};
+
+&i2c5 {
+	status = "okay";
 };
 
 &ltdc {


### PR DESCRIPTION
Enable i2c5 exposed by Arduino Uno V3 expansion board, which is mainly used for SE05X on LmP setups.

Signed-off-by: Igor Opaniuk <igor.opaniuk@foundries.io>