### PR TITLE
[FIO extras] ARM: dts: stm32mp157x-ev1: alias for i2c5 bus

### DIFF
--- a/arch/arm/boot/dts/stm32mp157a-ev1.dts
+++ b/arch/arm/boot/dts/stm32mp157a-ev1.dts
@@ -20,5 +20,6 @@
 		serial0 = &uart4;
 		serial1 = &usart3;
 		ethernet0 = &ethernet0;
+		i2c5 = &i2c5;
 	};
 };

--- a/arch/arm/boot/dts/stm32mp157c-ev1.dts
+++ b/arch/arm/boot/dts/stm32mp157c-ev1.dts
@@ -20,5 +20,6 @@
 		serial0 = &uart4;
 		serial1 = &usart3;
 		ethernet0 = &ethernet0;
+		i2c5 = &i2c5;
 	};
 };

--- a/arch/arm/boot/dts/stm32mp157d-ev1.dts
+++ b/arch/arm/boot/dts/stm32mp157d-ev1.dts
@@ -20,5 +20,6 @@
 		serial0 = &uart4;
 		serial1 = &usart3;
 		ethernet0 = &ethernet0;
+		i2c5 = &i2c5;
 	};
 };

--- a/arch/arm/boot/dts/stm32mp157f-ev1.dts
+++ b/arch/arm/boot/dts/stm32mp157f-ev1.dts
@@ -21,5 +21,6 @@
 		serial0 = &uart4;
 		serial1 = &usart3;
 		ethernet0 = &ethernet0;
+		i2c5 = &i2c5;
 	};
 };


### PR DESCRIPTION
Currently i2c5 (0x40015000) is enumerated as /dev/i2c-1: $ i2cdetect -l
i2c-0	i2c       	STM32F7 I2C(0x40013000)         	I2C adapter
i2c-1	i2c       	STM32F7 I2C(0x40015000)         	I2C adapter
i2c-2	i2c       	STM32F7 I2C(0x5c002000)         	I2C adapter

Add explicit alias for i2c5 to fix that.

Signed-off-by: Igor Opaniuk <igor.opaniuk@foundries.io>