### PR TITLE
ARM: dts: stm32mp157c-dk2: add alias for mmc0

### DIFF
--- a/arch/arm/boot/dts/stm32mp157c-dk2.dts
+++ b/arch/arm/boot/dts/stm32mp157c-dk2.dts
@@ -22,6 +22,7 @@
 		serial1 = &usart3;
 		serial2 = &uart7;
 		serial3 = &usart2;
+		mmc0 = &sdmmc1;
 	};
 
 	chosen {


### PR DESCRIPTION
Due to instability of mmc device probe order, define a mmc0 alias, so SD card is always probed as /dev/mmcblk0.

Cross-check devpath for SD controller:
$ udevadm info /dev/mmcblk0 | grep DEVPATH
E: DEVPATH=/devices/platform/soc/58005000.mmc/mmc_host/mmc0/mmc0:aaaa/block/mmcblk0

It's 58005000.mmc (defined as sdmmc1: mmc@58005000 node in DTS).

Check if alias is in place:
$ ls -la /proc/device-tree/aliases/ | grep mmc0
-r--r--r--    1 root     root            18 Apr 28 17:43 mmc0